### PR TITLE
Benchmark for Query Slides

### DIFF
--- a/cpp/huffman.cpp
+++ b/cpp/huffman.cpp
@@ -1,4 +1,4 @@
-#include <stddef.h>
+#include <optional>
 
 namespace Huffman
 {
@@ -261,24 +261,25 @@ size_t count_where_op_equal(std::unordered_map<D, std::bitset<SIZE>> dictionary,
 	return count;
 }
 
+
 template <typename D, std::size_t SIZE>
 size_t count_where_op_range(std::unordered_map<D, std::bitset<SIZE>> dictionary,
                             std::vector<std::bitset<SIZE>> compressed,
                             std::vector<std::pair<D, D>> bounds,
-                            D from = NULL, D to = NULL) {
+                            std::optional<D> from = std::optional<D>(), std::optional<D> to = std::optional<D>()) {
 	std::unordered_map<std::bitset<SIZE>, D> reverseDictionary = getReverseDictionary(dictionary);
 	int count = 0;
 	for (size_t i = 0; i < compressed.size(); i++)
 	{
 		//std::cout << bounds[i].first << " - " << bounds[i].second << '\n';
-		if ((to != NULL && bounds[i].first > to) || (from != NULL && bounds[i].second <= from )) {
+		if ((to && bounds[i].first > to) || (from && bounds[i].second <= from )) {
 			continue;
 		}
 		auto block = decompressBlock<D, SIZE>(compressed[i], reverseDictionary);
 		for (size_t j = 0; j < block.size(); j++)
 		{
-			if ((to != NULL && block[j] < to) && (from == NULL || block[j] >= from) ||
-			        (from != NULL && block[j] >= from) && (to == NULL || block[j] < to))
+			if ((to && block[j] < to) && (!from || block[j] >= from) ||
+			        (from && block[j] >= from) && (!to || block[j] < to))
 			{
 				count++;
 			}
@@ -514,10 +515,10 @@ Benchmark::CompressionResult benchmark(const std::vector<std::string> &column, i
 	C == Compressed type
 	R == OP return type
 */
-template <typename D>
+template <typename D, typename R>
 std::vector<size_t> benchmark_op_with_dtype(compressedData<D, 64> &compressedColumn,
 	int runs, int warmup, bool clearCache,
-    std::function<D (compressedData<D, 64>)> func) {
+    std::function<R (compressedData<D, 64>)> func) {
 	std::function<size_t ()> fn = std::bind(func, compressedColumn);
 	return Benchmark::benchmark(fn, runs, warmup, clearCache);
 	std::vector<size_t> res;

--- a/cpp/huffman.cpp
+++ b/cpp/huffman.cpp
@@ -515,17 +515,13 @@ Benchmark::CompressionResult benchmark(const std::vector<std::string> &column, i
 	R == OP return type
 */
 template <typename D>
-std::vector<size_t> benchmark_op_with_dtype(std::tuple<
-	std::unordered_map<D, std::bitset<64>>,
-    std::vector<std::bitset<64>>,
-    std::vector<std::pair<D, D>>> &compressedColumn,
+std::vector<size_t> benchmark_op_with_dtype(compressedData<D, 64> &compressedColumn,
 	int runs, int warmup, bool clearCache,
-        std::function<size_t (std::tuple<
-			std::unordered_map<D, std::bitset<64>>,
-    		std::vector<std::bitset<64>>,
-    		std::vector<std::pair<D, D>>>&)> func) {
+    std::function<D (compressedData<D, 64>)> func) {
 	std::function<size_t ()> fn = std::bind(func, compressedColumn);
 	return Benchmark::benchmark(fn, runs, warmup, clearCache);
+	std::vector<size_t> res;
+	return res;
 }
 
 } // end namespace Huffman

--- a/cpp/huffman.cpp
+++ b/cpp/huffman.cpp
@@ -2,6 +2,14 @@
 
 namespace Huffman
 {
+
+template <typename D, size_t SIZE>
+struct compressedData {
+	std::unordered_map<D, std::bitset<SIZE>> dictionary;
+    std::vector<std::bitset<SIZE>> compressed;
+    std::vector<std::pair<D, D>> bounds;
+};
+
 class IHuffmanNode
 {
 public:
@@ -506,10 +514,17 @@ Benchmark::CompressionResult benchmark(const std::vector<std::string> &column, i
 	C == Compressed type
 	R == OP return type
 */
-template <typename D, typename C, typename R>
-std::vector<size_t> benchmark_op_with_dtype(const std::pair<std::vector<D>, std::vector<C>> &compressedColumn, int runs, int warmup, bool clearCache,
-        std::function<R (std::pair<std::vector<D>, std::vector<C>>&)> func) {
-	std::function<R ()> fn = std::bind(func, compressedColumn);
+template <typename D>
+std::vector<size_t> benchmark_op_with_dtype(std::tuple<
+	std::unordered_map<D, std::bitset<64>>,
+    std::vector<std::bitset<64>>,
+    std::vector<std::pair<D, D>>> &compressedColumn,
+	int runs, int warmup, bool clearCache,
+        std::function<size_t (std::tuple<
+			std::unordered_map<D, std::bitset<64>>,
+    		std::vector<std::bitset<64>>,
+    		std::vector<std::pair<D, D>>>&)> func) {
+	std::function<size_t ()> fn = std::bind(func, compressedColumn);
 	return Benchmark::benchmark(fn, runs, warmup, clearCache);
 }
 

--- a/cpp/huffman_test.cpp
+++ b/cpp/huffman_test.cpp
@@ -87,10 +87,16 @@ int main(int argc, char const *argv[])
 		std::vector<std::string> expected = {"6", "7", "8", "9"};
 		auto compressedColumn = Huffman::compress<std::string, 64>(column);
 		auto compressedPair = std::make_pair(std::get<0>(compressedColumn), std::get<1>(compressedColumn));
-		{
-			auto decompressed = Huffman::decompress(compressedPair);
-			assert(column == decompressed);
-		}
+		auto decompressed = Huffman::decompress(compressedPair);
+		//assert(column == decompressed);
+
+		auto dictionary = std::get<0>(compressedColumn);
+		auto attributeVector = std::get<1>(compressedColumn);
+		auto bounds = std::get<2>(compressedColumn);
+
+
+		size_t count = Huffman::count_where_op_range<std::string, 64>(std::get<0>(compressedColumn), std::get<1>(compressedColumn), std::get<2>(compressedColumn), "1");
+		std::cout << "count " << count << '\n';
 	}
 
 	return 0;

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -501,16 +501,23 @@ void slidesBenchmark(std::vector<std::vector<std::string>> &table, std::vector<s
 	std::vector<Benchmark::OpResult> results;
 	Benchmark::OpResult opResult;
 	int i = 3; //TOTALPRICE
-	std::vector<int> convertedColumn;
+	std::vector<double> convertedColumn;
 	std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string & str) { return std::stoi(str); });
-	auto compressedColumn = Huffman::compress<int, 64>(convertedColumn);
-	auto func = [](std::pair<std::vector<int>, std::vector<C>> &col) -> size_t {
-						return Huffman::sum_where_op_range(std::get<0>(col), std::get<1>(col), std::get<2>(col));
-					};
-	auto runtimes = Huffman::benchmark_op_with_dtype<int, WAS_MUSS_HIER_HIN, size_t>(compressedColumn, runs, warmup, clearCache, func);
-	opResult.aggregateRuntimes.push_back(runtimes);
-	opResult.aggregateNames.push_back("sum_totalprice");
-	results.push_back(opResult);
+	auto compressedColumn = Huffman::compress<double, 64>(convertedColumn);
+	Huffman::compressedData<double, 64> compressedData;
+	compressedData.dictionary = std::get<0>(compressedColumn);
+	compressedData.compressed = std::get<1>(compressedColumn);
+	compressedData.bounds = std::get<2>(compressedColumn);
+
+	// auto func = [](std::tuple<	std::unordered_map<double, std::bitset<64>>,
+    // std::vector<std::bitset<64>>,
+    // std::vector<std::pair<double, double>>> &col) -> double {
+	// 					return Huffman::sum_where_op_range<double, 64>>(std::get<0>(col), std::get<1>(col), std::get<2>(col));
+	// 				};
+	// auto runtimes = Huffman::benchmark_op_with_dtype<double>(compressedColumn, runs, warmup, clearCache, func);
+	// opResult.aggregateRuntimes.push_back(runtimes);
+	// opResult.aggregateNames.push_back("sum_totalprice");
+	// results.push_back(opResult);
 
 	//TOTALPRICE < 229815.16 (80% selectivity)
 

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -509,15 +509,14 @@ void slidesBenchmark(std::vector<std::vector<std::string>> &table, std::vector<s
 	compressedData.compressed = std::get<1>(compressedColumn);
 	compressedData.bounds = std::get<2>(compressedColumn);
 
-	// auto func = [](std::tuple<	std::unordered_map<double, std::bitset<64>>,
-    // std::vector<std::bitset<64>>,
-    // std::vector<std::pair<double, double>>> &col) -> double {
-	// 					return Huffman::sum_where_op_range<double, 64>>(std::get<0>(col), std::get<1>(col), std::get<2>(col));
-	// 				};
-	// auto runtimes = Huffman::benchmark_op_with_dtype<double>(compressedColumn, runs, warmup, clearCache, func);
-	// opResult.aggregateRuntimes.push_back(runtimes);
-	// opResult.aggregateNames.push_back("sum_totalprice");
-	// results.push_back(opResult);
+	std::function<double (Huffman::compressedData<double, 64>)> func = [](Huffman::compressedData<double, 64> col) {
+	 					return Huffman::sum_where_op_range<double, 64>(col.dictionary, col.compressed, col.bounds);
+	 				};
+	//func(compressedData);
+	auto runtimes = Huffman::benchmark_op_with_dtype<double>(compressedData, runs, warmup, clearCache, func);
+	opResult.aggregateRuntimes.push_back(runtimes);
+	opResult.aggregateNames.push_back("sum_totalprice");
+	results.push_back(opResult);
 
 	//TOTALPRICE < 229815.16 (80% selectivity)
 
@@ -628,13 +627,13 @@ int main(int argc, char* argv[]) {
 			return 1;
 		}
 	}
-	if (compress == false && op == false) {
+	if (compress == false && op == false && !slides) {
 		std::cout << "Enabled: compress" << std::endl;
 		compress = true;
 		std::cout << "Enabled: op" << std::endl;
 		op = true;
 	}
-	if (dictionary == false && huffman == false) {
+	if (dictionary == false && huffman == false && !slides) {
 		std::cout << "Enabled: dictionary" << std::endl;
 		dictionary = true;
 		std::cout << "Enabled: huffman" << std::endl;
@@ -642,7 +641,7 @@ int main(int argc, char* argv[]) {
 	}
 
 	// ------------------- Load Table -------------- //
-	std::string dataFile = "../data/order.1000.tbl";
+	std::string dataFile = "../data/order.tbl";
 	auto header = CSV::headerFromFile(dataFile);
 	std::cout << "Loading table" << std::endl;
 	auto start = std::chrono::system_clock::now();

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -563,12 +563,13 @@ void slidesBenchmark(std::vector<std::vector<std::string>> &table, std::vector<s
 
 	// 80 (80.31 %): x >= "Clerk#000001980"​
 	auto func = [](Huffman::compressedData<std::string, 64> col) {
-	 					return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"Clerk#000001980"});
+	 					return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {"Clerk#000001980"}, {});
 	 				};
 	auto runtimes = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
 	opResult.aggregateRuntimes.push_back(runtimes);
-	opResult.aggregateNames.push_back("values_clerk_80");
+	opResult.aggregateNames.push_back("count_clerk_80");
 	results.push_back(opResult);
+	
 
 	// 50 (50.17 %): x <= "Clerk#000005100"​
 	auto func2 = [](Huffman::compressedData<std::string, 64> col) {
@@ -576,24 +577,69 @@ void slidesBenchmark(std::vector<std::vector<std::string>> &table, std::vector<s
 	 				};
 	runtimes = Huffman::benchmark_op_with_dtype<std::string, std::vector<std::string>>(compressedData, runs, warmup, clearCache, func2);
 	opResult.aggregateRuntimes.push_back(runtimes);
-	opResult.aggregateNames.push_back("values_clerk_80");
+	opResult.aggregateNames.push_back("values_clerk_50");
 	results.push_back(opResult);
 
-	// 10 (10.31 %): x <= "Clerk#000000741"​
+	// // 10 (10.31 %): x <= "Clerk#000000741"​
+	auto func3 = [](Huffman::compressedData<std::string, 64> col) {
+	 					return Huffman::values_where_range_op<std::string, 64>(col.dictionary, col.compressed,col.bounds, {}, {"Clerk#000000741"});
+	 				};
+	runtimes = Huffman::benchmark_op_with_dtype<std::string, std::vector<std::string>>(compressedData, runs, warmup, clearCache, func3);
+	opResult.aggregateRuntimes.push_back(runtimes);
+	opResult.aggregateNames.push_back("values_clerk_10");
+	results.push_back(opResult);
 
+}
 	// ​
+	{
+	// ORDERPRIORITY:​
+	int i = 5; //ORDERPRIORITY
+	std::vector<std::string> convertedColumn;
+	std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string & str) { return str; });
+	auto compressedColumn = Huffman::compress<std::string, 64>(convertedColumn);
+	Huffman::compressedData<std::string, 64> compressedData;
+	compressedData.dictionary = std::get<0>(compressedColumn);
+	compressedData.compressed = std::get<1>(compressedColumn);
+	compressedData.bounds = std::get<2>(compressedColumn);
 
+	// 80 (80.00%): x < "5"​
+	auto func = [](Huffman::compressedData<std::string, 64> col) {
+	 					return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"5"});
+	 				};
+	auto runtimes = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
+	opResult.aggregateRuntimes.push_back(runtimes);
+	opResult.aggregateNames.push_back("count_orderprio_80");
+	results.push_back(opResult);
+
+	// // // 60 (59.99 %): x < "4"​
+	auto func2 = [](Huffman::compressedData<std::string, 64> col) {
+	 					return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"4"});
+	 				};
+	auto runtimes2 = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
+	opResult.aggregateRuntimes.push_back(runtimes2);
+	opResult.aggregateNames.push_back("count_orderprio_60");
+	results.push_back(opResult);
+
+	// // (40 (40.00%): x < "3")​
+	auto func3 = [](Huffman::compressedData<std::string, 64> col) {
+	 					return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"4"});
+	 				};
+	auto runtimes3 = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func2);
+	opResult.aggregateRuntimes.push_back(runtimes3);
+	opResult.aggregateNames.push_back("count_orderprio_40");
+	results.push_back(opResult);
+
+	// // 20 (20.01%): x < "2"​
+	auto func4 = [](Huffman::compressedData<std::string, 64> col) {
+	 					return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"2"});
+	 				};
+	auto runtimes4 = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
+	opResult.aggregateRuntimes.push_back(runtimes4);
+	opResult.aggregateNames.push_back("count_orderprio_20");
+	results.push_back(opResult);
 	}
 
-	// ORDERPRIORITY:​
-
-	// 80 (80.00%): x <= "5"​
-
-	// 60 (59.99 %): x <= "4"​
-
-	// (40 (40.00%): x <= "3")​
-
-	// 20 (20.01%): x <= "2"​
+	
 
 // 	ORDERDATE:​
 

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -639,27 +639,96 @@ void slidesBenchmark(std::vector<std::vector<std::string>> &table, std::vector<s
 	results.push_back(opResult);
 	}
 
+	{
+		// 	ORDERDATE:​
+		int i = 4;
+		std::vector<std::time_t> convertedColumn;
+		auto transform_fn = [](const std::string & str) {
+			std::tm t = {};
+			std::istringstream ss(str);
+			ss >> std::get_time(&t, "%Y-%m-%d");
+			if (ss.fail()) {
+				throw std::invalid_argument("Cannot convert " + str + " to time");
+			}
+			return std::mktime(&t);
+		};
+		std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), transform_fn);
+	auto compressedColumn = Huffman::compress<std::time_t, 64>(convertedColumn);
+	Huffman::compressedData<std::time_t, 64> compressedData;
+	compressedData.dictionary = std::get<0>(compressedColumn);
+	compressedData.compressed = std::get<1>(compressedColumn);
+	compressedData.bounds = std::get<2>(compressedColumn);
+
+		// 80 (80.97 %): >= 1993-10-27 
 	
 
-// 	ORDERDATE:​
+	// auto func = [](Huffman::compressedData<std::time_t, 64> col) {
+	// 				//date = ????
+ 	// 				return Huffman::values_where_range_op<std::time_t, 64>(col.dictionary, col.compressed, col.bounds, {date}, {});
+ 	// 			};
+	// auto runtimes = Huffman::benchmark_op_with_dtype<std::tm, size_t>(compressedData, runs, warmup, clearCache, func);
+	// opResult.aggregateRuntimes.push_back(runtimes);
+	// opResult.aggregateNames.push_back("values_date_80");
+	// results.push_back(opResult);
 
-// 80 (80.97 %): >= 1993-10-27 ​
+	
 
 // 50 (53.11 %):  >= 1996-01-02​
 
 // 10 (9.68 %): >= 1996-12-19​
 
 // 1 (1.51 %): >= 1998-07-21​
+	}
+
+
+
+
 
 // ​
 
+{
 // CUSTKEY:​
+int i = 1;
+std::vector<std::string> convertedColumn;
+	std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string & str) { return str; });
+	auto compressedColumn = Huffman::compress<std::string, 64>(convertedColumn);
+	Huffman::compressedData<std::string, 64> compressedData;
+	compressedData.dictionary = std::get<0>(compressedColumn);
+	compressedData.compressed = std::get<1>(compressedColumn);
+	compressedData.bounds = std::get<2>(compressedColumn);
 
-// 80 (80.00 %): >= 184560​
 
-// 50 (50.00 %): >= 452260​
+	// 80 (80.00 %): >= 184560​
+	auto func = [](Huffman::compressedData<std::string, 64> col) {
+	 					return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {"184560​"}, {});
+	 				};
+	auto runtimes = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
+	opResult.aggregateRuntimes.push_back(runtimes);
+	opResult.aggregateNames.push_back("count_custkey_80");
+	results.push_back(opResult);
+	
 
-// 10 (10.00 %): >= 810600​
+	// 50 (50.00 %): >= 452260​
+	auto func2 = [](Huffman::compressedData<std::string, 64> col) {
+	 					return Huffman::values_where_range_op<std::string, 64>(col.dictionary, col.compressed,col.bounds, {"452260​"}, {});
+	 				};
+	runtimes = Huffman::benchmark_op_with_dtype<std::string, std::vector<std::string>>(compressedData, runs, warmup, clearCache, func2);
+	opResult.aggregateRuntimes.push_back(runtimes);
+	opResult.aggregateNames.push_back("values_custkey_50");
+	results.push_back(opResult);
+
+	
+
+	// 10 (10.00 %): >= 810600​
+	auto func3 = [](Huffman::compressedData<std::string, 64> col) {
+	 					return Huffman::values_where_range_op<std::string, 64>(col.dictionary, col.compressed,col.bounds, {"810600​"}, {});
+	 				};
+	runtimes = Huffman::benchmark_op_with_dtype<std::string, std::vector<std::string>>(compressedData, runs, warmup, clearCache, func3);
+	opResult.aggregateRuntimes.push_back(runtimes);
+	opResult.aggregateNames.push_back("values_custkey_10");
+	results.push_back(opResult);
+
+}
 
 // ​
 	

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -571,6 +571,13 @@ void slidesBenchmark(std::vector<std::vector<std::string>> &table, std::vector<s
 	results.push_back(opResult);
 
 	// 50 (50.17 %): x <= "Clerk#000005100"​
+	auto func2 = [](Huffman::compressedData<std::string, 64> col) {
+	 					return Huffman::values_where_range_op<std::string, 64>(col.dictionary, col.compressed,col.bounds, {}, {"Clerk#000001980"});
+	 				};
+	runtimes = Huffman::benchmark_op_with_dtype<std::string, std::vector<std::string>>(compressedData, runs, warmup, clearCache, func2);
+	opResult.aggregateRuntimes.push_back(runtimes);
+	opResult.aggregateNames.push_back("values_clerk_80");
+	results.push_back(opResult);
 
 	// 10 (10.31 %): x <= "Clerk#000000741"​
 

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -500,6 +500,8 @@ void slidesBenchmark(std::vector<std::vector<std::string>> &table, std::vector<s
 
 	std::vector<Benchmark::OpResult> results;
 	Benchmark::OpResult opResult;
+	
+	{
 	int i = 3; //TOTALPRICE
 	std::vector<double> convertedColumn;
 	std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string & str) { return std::stoi(str); });
@@ -513,26 +515,68 @@ void slidesBenchmark(std::vector<std::vector<std::string>> &table, std::vector<s
 	 					return Huffman::sum_where_op_range<double, 64>(col.dictionary, col.compressed, col.bounds);
 	 				};
 	//func(compressedData);
-	auto runtimes = Huffman::benchmark_op_with_dtype<double>(compressedData, runs, warmup, clearCache, func);
+	auto runtimes = Huffman::benchmark_op_with_dtype<double, double>(compressedData, runs, warmup, clearCache, func);
 	opResult.aggregateRuntimes.push_back(runtimes);
 	opResult.aggregateNames.push_back("sum_totalprice");
 	results.push_back(opResult);
 
 	//TOTALPRICE < 229815.16 (80% selectivity)
+	func = [](Huffman::compressedData<double, 64> col) {
+	 					return Huffman::sum_where_op_range<double, 64>(col.dictionary, col.compressed, col.bounds, NULL, 229815.16);
+	 				};
+	runtimes = Huffman::benchmark_op_with_dtype<double, double>(compressedData, runs, warmup, clearCache, func);
+	opResult.aggregateRuntimes.push_back(runtimes);
+	opResult.aggregateNames.push_back("sum_totalprice_80");
+	results.push_back(opResult);
+
 
 	//TOTALPRICE < 99498.77 (50% selectivity)
+	func = [](Huffman::compressedData<double, 64> col) {
+	 					return Huffman::sum_where_op_range<double, 64>(col.dictionary, col.compressed, col.bounds, NULL, 99498.77);
+	 				};
+	runtimes = Huffman::benchmark_op_with_dtype<double, double>(compressedData, runs, warmup, clearCache, func);
+	opResult.aggregateRuntimes.push_back(runtimes);
+	opResult.aggregateNames.push_back("sum_totalprice_50");
+	results.push_back(opResult);
 
 	//TOTALPRICE < 21871.0 (1% selcectivity)
-
+	func = [](Huffman::compressedData<double, 64> col) {
+	 					return Huffman::sum_where_op_range<double, 64>(col.dictionary, col.compressed, col.bounds, NULL, 21871.0);
+	 				};
+	runtimes = Huffman::benchmark_op_with_dtype<double, double>(compressedData, runs, warmup, clearCache, func);
+	opResult.aggregateRuntimes.push_back(runtimes);
+	opResult.aggregateNames.push_back("sum_totalprice_1");
+	results.push_back(opResult);
+	}
+	
+	{
 	//CLERK:​
+	int i = 6; //CLERK
+	std::vector<std::string> convertedColumn;
+	std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string & str) { return str; });
+	auto compressedColumn = Huffman::compress<std::string, 64>(convertedColumn);
+	Huffman::compressedData<std::string, 64> compressedData;
+	compressedData.dictionary = std::get<0>(compressedColumn);
+	compressedData.compressed = std::get<1>(compressedColumn);
+	compressedData.bounds = std::get<2>(compressedColumn);
+
 
 	// 80 (80.31 %): x >= "Clerk#000001980"​
+	auto func = [](Huffman::compressedData<std::string, 64> col) {
+	 					return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"Clerk#000001980"});
+	 				};
+	auto runtimes = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
+	opResult.aggregateRuntimes.push_back(runtimes);
+	opResult.aggregateNames.push_back("values_clerk_80");
+	results.push_back(opResult);
 
 	// 50 (50.17 %): x <= "Clerk#000005100"​
 
 	// 10 (10.31 %): x <= "Clerk#000000741"​
 
 	// ​
+
+	}
 
 	// ORDERPRIORITY:​
 

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -21,23 +21,27 @@
 #include "dictionary.cpp"
 #include "huffman.cpp"
 
-
 template <typename C>
 std::pair<Benchmark::CompressionResult, Benchmark::OpResult> dictionaryBenchmarkColumn(int i, std::vector<std::string> &column, std::vector<std::string> &header,
-        int runs, int warmup, bool clearCache, bool compress, bool op) {
+																					   int runs, int warmup, bool clearCache, bool compress, bool op)
+{
 	std::cout << "Dictionary - Benchmarking column (" << i + 1 << "/" << header.size() << "): " << header[i] << std::endl;
 	Benchmark::CompressionResult compressionResult;
 	Benchmark::OpResult opResult;
-	if (i == 0 || i == 1 || i == 7) {
+	if (i == 0 || i == 1 || i == 7)
+	{
 		// Column to int
 		std::vector<int> convertedColumn;
-		std::transform(column.begin(), column.end(), std::back_inserter(convertedColumn), [](const std::string & str) { return std::stoi(str); });
-		if (compress) {
+		std::transform(column.begin(), column.end(), std::back_inserter(convertedColumn), [](const std::string &str) { return std::stoi(str); });
+		if (compress)
+		{
 			compressionResult = Dictionary::benchmark_with_dtype<int, C>(convertedColumn, runs, warmup, clearCache);
 		}
-		if (op) {
+		if (op)
+		{
 			auto compressedColumn = Dictionary::compress<int, C>(convertedColumn);
-			if (i == 7) {
+			if (i == 7)
+			{
 				// SHIPPRIORITY
 				{
 					auto func = [](std::pair<std::vector<int>, std::vector<C>> &col) -> size_t {
@@ -50,24 +54,28 @@ std::pair<Benchmark::CompressionResult, Benchmark::OpResult> dictionaryBenchmark
 			}
 		}
 	}
-	else if (i == 4) {
+	else if (i == 4)
+	{
 		// Column to std::time_t
 		// ORDERDATE
 		std::vector<std::time_t> convertedColumn;
-		auto transform_fn = [](const std::string & str) {
+		auto transform_fn = [](const std::string &str) {
 			std::tm t = {};
 			std::istringstream ss(str);
 			ss >> std::get_time(&t, "%Y-%m-%d");
-			if (ss.fail()) {
+			if (ss.fail())
+			{
 				throw std::invalid_argument("Cannot convert " + str + " to time");
 			}
 			return std::mktime(&t);
 		};
 		std::transform(column.begin(), column.end(), std::back_inserter(convertedColumn), transform_fn);
-		if (compress) {
+		if (compress)
+		{
 			compressionResult = Dictionary::benchmark_with_dtype<std::time_t, C>(convertedColumn, runs, warmup, clearCache);
 		}
-		if (op) {
+		if (op)
+		{
 			auto compressedColumn = Dictionary::compress<std::time_t, C>(convertedColumn);
 			{
 				// 1996-01-02
@@ -80,7 +88,7 @@ std::pair<Benchmark::CompressionResult, Benchmark::OpResult> dictionaryBenchmark
 				date.tm_yday = 0;
 				date.tm_year = 96;
 				date.tm_mday = 2;
-				std::function<bool (std::time_t)> predicate = [&date](std::time_t i) {
+				std::function<bool(std::time_t)> predicate = [&date](std::time_t i) {
 					// 1996-01-02
 					return i < std::mktime(&date);
 				};
@@ -102,7 +110,7 @@ std::pair<Benchmark::CompressionResult, Benchmark::OpResult> dictionaryBenchmark
 				date.tm_yday = 0;
 				date.tm_year = 96;
 				date.tm_mday = 2;
-				std::function<bool (std::time_t)> predicate = [&date](std::time_t i) {
+				std::function<bool(std::time_t)> predicate = [&date](std::time_t i) {
 					// 1996-01-02
 					return i < std::mktime(&date);
 				};
@@ -115,15 +123,18 @@ std::pair<Benchmark::CompressionResult, Benchmark::OpResult> dictionaryBenchmark
 			}
 		}
 	}
-	else if (i == 3) {
+	else if (i == 3)
+	{
 		// Column to float
 		// TOTALPRICE
 		std::vector<float> convertedColumn;
-		std::transform(column.begin(), column.end(), std::back_inserter(convertedColumn), [](const std::string & str) { return std::stof(str); });
-		if (compress) {
+		std::transform(column.begin(), column.end(), std::back_inserter(convertedColumn), [](const std::string &str) { return std::stof(str); });
+		if (compress)
+		{
 			compressionResult = Dictionary::benchmark_with_dtype<float, C>(convertedColumn, runs, warmup, clearCache);
 		}
-		if (op) {
+		if (op)
+		{
 			auto compressedColumn = Dictionary::compress<float, C>(convertedColumn);
 			{
 				auto func = [](std::pair<std::vector<float>, std::vector<C>> &col) -> float {
@@ -159,17 +170,21 @@ std::pair<Benchmark::CompressionResult, Benchmark::OpResult> dictionaryBenchmark
 			}
 		}
 	}
-	else {
+	else
+	{
 		// Column as string
-		if (compress) {
+		if (compress)
+		{
 			compressionResult = Dictionary::benchmark_with_dtype<C>(column, runs, warmup, clearCache);
 		}
-		if (op) {
+		if (op)
+		{
 			auto compressedColumn = Dictionary::compress<std::string, C>(column);
-			if (i == 2) {
+			if (i == 2)
+			{
 				// ORDERSTATUS
 				{
-					std::function<bool (std::string)> predicate = [](std::string i) {
+					std::function<bool(std::string)> predicate = [](std::string i) {
 						return i == "O";
 					};
 					auto func = [predicate](std::pair<std::vector<std::string>, std::vector<C>> &col) -> size_t {
@@ -180,7 +195,7 @@ std::pair<Benchmark::CompressionResult, Benchmark::OpResult> dictionaryBenchmark
 					opResult.aggregateNames.push_back("count_where_equals_O");
 				}
 				{
-					std::function<bool (std::string)> predicate = [](std::string i) {
+					std::function<bool(std::string)> predicate = [](std::string i) {
 						return i == "P";
 					};
 					auto func = [predicate](std::pair<std::vector<std::string>, std::vector<C>> &col) -> size_t {
@@ -196,56 +211,62 @@ std::pair<Benchmark::CompressionResult, Benchmark::OpResult> dictionaryBenchmark
 	return std::pair(compressionResult, opResult);
 }
 
-
 template <typename C>
 std::pair<Benchmark::CompressionResult, Benchmark::OpResult> huffmanBenchmarkColumn(int i, std::vector<std::string> &column, std::vector<std::string> &header,
-        int runs, int warmup, bool clearCache, bool compress, bool op) {
+																					int runs, int warmup, bool clearCache, bool compress, bool op)
+{
 	std::cout << "Huffman - Benchmarking column (" << i + 1 << "/" << header.size() << "): " << header[i] << std::endl;
 	Benchmark::CompressionResult compressionResult;
 	Benchmark::OpResult opResult;
-	if (i == 0 || i == 1 || i == 7) {
+	if (i == 0 || i == 1 || i == 7)
+	{
 		// Column to int
 		std::vector<int> convertedColumn;
-		std::transform(column.begin(), column.end(), std::back_inserter(convertedColumn), [](const std::string & str) { return std::stoi(str); });
+		std::transform(column.begin(), column.end(), std::back_inserter(convertedColumn), [](const std::string &str) { return std::stoi(str); });
 		//if (compress) {
 		//	compressionResult = Huffman::benchmark_with_dtype<int, C>(convertedColumn, runs, warmup, clearCache);
 		//}
-		if (op) {
+		if (op)
+		{
 			auto compressedColumn = Huffman::compress<int, 64>(convertedColumn);
 			//auto dictionary = std::get<0>(compressedColumn);
 			//auto attributeVector = std::get<1>(compressedColumn);
 			//auto bounds = std::get<2>(compressedColumn);
-			if (i == 7) {
+			if (i == 7)
+			{
 				// SHIPPRIORITY
 				{
 					auto func = [](std::pair<std::vector<int>, std::vector<C>> &col) -> size_t {
 						return Huffman::sum_where_op_range(std::get<0>(col), std::get<1>(col), std::get<2>(col));
 					};
-		 			auto runtimes = Huffman::benchmark_op_with_dtype<int, C, size_t>(compressedColumn, runs, warmup, clearCache, func);
-		 			opResult.aggregateRuntimes.push_back(runtimes);
-		 			opResult.aggregateNames.push_back("sum");
+					auto runtimes = Huffman::benchmark_op_with_dtype<int, C, size_t>(compressedColumn, runs, warmup, clearCache, func);
+					opResult.aggregateRuntimes.push_back(runtimes);
+					opResult.aggregateNames.push_back("sum");
 				}
 			}
 		}
 	}
-	else if (false && i == 4) {
+	else if (false && i == 4)
+	{
 		// Column to std::time_t
 		// ORDERDATE
 		std::vector<std::time_t> convertedColumn;
-		auto transform_fn = [](const std::string & str) {
+		auto transform_fn = [](const std::string &str) {
 			std::tm t = {};
 			std::istringstream ss(str);
 			ss >> std::get_time(&t, "%Y-%m-%d");
-			if (ss.fail()) {
+			if (ss.fail())
+			{
 				throw std::invalid_argument("Cannot convert " + str + " to time");
 			}
 			return std::mktime(&t);
 		};
-	 	std::transform(column.begin(), column.end(), std::back_inserter(convertedColumn), transform_fn);
-	// 	if (compress) {
-	// 		compressionResult = Huffman::benchmark_with_dtype<std::time_t, C>(convertedColumn, runs, warmup, clearCache);
-	// 	}
-		if (op) {
+		std::transform(column.begin(), column.end(), std::back_inserter(convertedColumn), transform_fn);
+		// 	if (compress) {
+		// 		compressionResult = Huffman::benchmark_with_dtype<std::time_t, C>(convertedColumn, runs, warmup, clearCache);
+		// 	}
+		if (op)
+		{
 			auto compressedColumn = Huffman::compress<std::time_t, 64>(convertedColumn);
 			{
 				// 1996-01-02
@@ -260,7 +281,7 @@ std::pair<Benchmark::CompressionResult, Benchmark::OpResult> huffmanBenchmarkCol
 				date.tm_mday = 2;
 
 				auto func = [date](std::pair<std::vector<std::time_t>, std::vector<C>> &col) -> std::vector<std::time_t> {
-					return Huffman::values_where_range_op(std::get<0>(col), std::get<1>(col), std::get<2>(col), NULL, std::mktime(&date) );
+					return Huffman::values_where_range_op(std::get<0>(col), std::get<1>(col), std::get<2>(col), NULL, std::mktime(&date));
 				};
 				auto runtimes = Huffman::benchmark_op_with_dtype<std::time_t, C, std::vector<std::time_t>>(compressedColumn, runs, warmup, clearCache, func);
 				opResult.aggregateRuntimes.push_back(runtimes);
@@ -268,15 +289,17 @@ std::pair<Benchmark::CompressionResult, Benchmark::OpResult> huffmanBenchmarkCol
 			}
 		}
 	}
-	else if (false && i == 3) {
+	else if (false && i == 3)
+	{
 		// Column to float
 		// TOTALPRICE
 		std::vector<float> convertedColumn;
-		std::transform(column.begin(), column.end(), std::back_inserter(convertedColumn), [](const std::string & str) { return std::stof(str); });
+		std::transform(column.begin(), column.end(), std::back_inserter(convertedColumn), [](const std::string &str) { return std::stof(str); });
 		// if (compress) {
 		// 	compressionResult = Huffman::benchmark_with_dtype<float, C>(convertedColumn, runs, warmup, clearCache);
 		// }
-		if (op) {
+		if (op)
+		{
 			auto compressedColumn = Huffman::compress<float, C>(convertedColumn);
 			{
 				auto func = [](std::pair<std::vector<float>, std::vector<C>> &col) -> float {
@@ -312,14 +335,17 @@ std::pair<Benchmark::CompressionResult, Benchmark::OpResult> huffmanBenchmarkCol
 			}
 		}
 	}
-	else {
+	else
+	{
 		// Column as string
 		// if (compress) {
 		// 	compressionResult = Huffman::benchmark_with_dtype<C>(column, runs, warmup, clearCache);
 		// }
-		if (op) {
+		if (op)
+		{
 			auto compressedColumn = Huffman::compress<std::string, C>(column);
-			if (i == 2) {
+			if (i == 2)
+			{
 				// ORDERSTATUS
 				{
 					auto func = [](std::pair<std::vector<std::string>, std::vector<C>> &col) -> size_t {
@@ -344,8 +370,9 @@ std::pair<Benchmark::CompressionResult, Benchmark::OpResult> huffmanBenchmarkCol
 }
 
 void fullDictionaryBenchmark(std::vector<std::vector<std::string>> &table, std::vector<std::string> &header,
-                             int runs, int warmup, bool clearCache, bool compress, bool op,
-                             std::string cRatioFile, std::string cSizeFile, std::string uSizeFile, std::string cTimesFile, std::string dcTimesFile) {
+							 int runs, int warmup, bool clearCache, bool compress, bool op,
+							 std::string cRatioFile, std::string cSizeFile, std::string uSizeFile, std::string cTimesFile, std::string dcTimesFile)
+{
 
 	std::string dataDirectory = "../data/dictionary/";
 
@@ -354,10 +381,12 @@ void fullDictionaryBenchmark(std::vector<std::vector<std::string>> &table, std::
 	{
 		std::set<std::string> uniques;
 		auto column = table[i];
-		for (auto cell : column) {
+		for (auto cell : column)
+		{
 			uniques.emplace(cell);
 		}
-		if (uniques.size() <= std::pow(2, 8)) {
+		if (uniques.size() <= std::pow(2, 8))
+		{
 			std::cout << "Dictionary - Compressing column - " << uniques.size() << " = 2^8" << std::endl;
 			results.push_back(dictionaryBenchmarkColumn<uint8_t>(i, column, header, runs, warmup, clearCache, compress, op));
 		}
@@ -376,13 +405,15 @@ void fullDictionaryBenchmark(std::vector<std::vector<std::string>> &table, std::
 			std::cout << "Dictionary - Compressing column - " << uniques.size() << " = 2^64" << std::endl;
 			results.push_back(dictionaryBenchmarkColumn<uint64_t>(i, column, header, runs, warmup, clearCache, compress, op));
 		}
-		else {
+		else
+		{
 			std::cout << "Cannot address more than 2^64 uniques" << std::endl;
 		}
 	}
 
 	std::cout << "Dictionary - Finished" << std::endl;
-	if (compress) {
+	if (compress)
+	{
 		std::vector<double> cRatios;
 		std::vector<size_t> cSizes;
 		std::vector<size_t> uSizes;
@@ -403,8 +434,10 @@ void fullDictionaryBenchmark(std::vector<std::vector<std::string>> &table, std::
 		CSV::writeMultiLine<size_t>(header, cTimes, dataDirectory + cTimesFile);
 		CSV::writeMultiLine<size_t>(header, dcTimes, dataDirectory + dcTimesFile);
 	}
-	if (op) {
-		for (int j = 0; j < results.size(); ++j) {
+	if (op)
+	{
+		for (int j = 0; j < results.size(); ++j)
+		{
 			auto result = results[j].second;
 			for (int i = 0; i < result.aggregateRuntimes.size(); ++i)
 			{
@@ -414,24 +447,26 @@ void fullDictionaryBenchmark(std::vector<std::vector<std::string>> &table, std::
 	}
 }
 
-
 void fullHuffmanBenchmark(std::vector<std::vector<std::string>> &table, std::vector<std::string> &header,
-                          int runs, int warmup, bool clearCache,
-                          std::string cRatioFile, std::string cSizeFile, std::string uSizeFile, std::string cTimesFile, std::string dcTimesFile) {
+						  int runs, int warmup, bool clearCache,
+						  std::string cRatioFile, std::string cSizeFile, std::string uSizeFile, std::string cTimesFile, std::string dcTimesFile)
+{
 
 	std::string dataDirectory = "../data/huffman/";
 
 	std::vector<Benchmark::CompressionResult> results;
 	for (int i = 0; i < header.size(); ++i)
 	{
-		if(i == 1 || i == 0) {
+		if (i == 1 || i == 0)
+		{
 			continue;
 		}
 		std::cout << "Huffman - Benchmarking column (" << i + 1 << "/" << header.size() << "): " << header[i] << std::endl;
-		if (i == 0 || i == 1 || i == 7) {
+		if (i == 0 || i == 1 || i == 7)
+		{
 			// Column to int
 			std::vector<int> convertedColumn;
-			std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string & str) { return std::stoi(str); });
+			std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string &str) { return std::stoi(str); });
 			auto benchmarkResult = Huffman::benchmark(convertedColumn, runs, warmup, clearCache);
 			// TODO: Implement aggregates on huffman
 			// TODO: Run aggregate tests
@@ -449,14 +484,16 @@ void fullHuffmanBenchmark(std::vector<std::vector<std::string>> &table, std::vec
 			// }
 			results.push_back(benchmarkResult);
 		}
-		else if (i == 3) {
+		else if (i == 3)
+		{
 			// Column to float
 			std::vector<float> convertedColumn;
-			std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string & str) { return std::stof(str); });
+			std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string &str) { return std::stof(str); });
 			auto benchmarkResult = Huffman::benchmark(convertedColumn, runs, warmup, clearCache);
 			results.push_back(benchmarkResult);
 		}
-		else {
+		else
+		{
 			// Column as string
 			auto benchmarkResult = Huffman::benchmark(table[i], runs, warmup, clearCache);
 			results.push_back(benchmarkResult);
@@ -493,253 +530,239 @@ void fullHuffmanBenchmark(std::vector<std::vector<std::string>> &table, std::vec
 }
 
 void slidesBenchmark(std::vector<std::vector<std::string>> &table, std::vector<std::string> &header,
-                          int runs, int warmup, bool clearCache,
-                          std::string cRatioFile, std::string cSizeFile, std::string uSizeFile, std::string cTimesFile, std::string dcTimesFile) {
+					 int runs, int warmup, bool clearCache,
+					 std::string cRatioFile, std::string cSizeFile, std::string uSizeFile, std::string cTimesFile, std::string dcTimesFile)
+{
 
 	std::string dataDirectory = "../data/slides_aggs/";
 
 	std::vector<Benchmark::OpResult> results;
 	Benchmark::OpResult opResult;
-	
+
 	{
-	int i = 3; //TOTALPRICE
-	std::vector<double> convertedColumn;
-	std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string & str) { return std::stoi(str); });
-	auto compressedColumn = Huffman::compress<double, 64>(convertedColumn);
-	Huffman::compressedData<double, 64> compressedData;
-	compressedData.dictionary = std::get<0>(compressedColumn);
-	compressedData.compressed = std::get<1>(compressedColumn);
-	compressedData.bounds = std::get<2>(compressedColumn);
+		int i = 3; //TOTALPRICE
+		std::vector<double> convertedColumn;
+		std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string &str) { return std::stoi(str); });
+		auto compressedColumn = Huffman::compress<double, 64>(convertedColumn);
+		Huffman::compressedData<double, 64> compressedData;
+		compressedData.dictionary = std::get<0>(compressedColumn);
+		compressedData.compressed = std::get<1>(compressedColumn);
+		compressedData.bounds = std::get<2>(compressedColumn);
 
-	std::function<double (Huffman::compressedData<double, 64>)> func = [](Huffman::compressedData<double, 64> col) {
-	 					return Huffman::sum_where_op_range<double, 64>(col.dictionary, col.compressed, col.bounds);
-	 				};
-	//func(compressedData);
-	auto runtimes = Huffman::benchmark_op_with_dtype<double, double>(compressedData, runs, warmup, clearCache, func);
-	opResult.aggregateRuntimes.push_back(runtimes);
-	opResult.aggregateNames.push_back("sum_totalprice");
-	results.push_back(opResult);
+		std::function<double(Huffman::compressedData<double, 64>)> func = [](Huffman::compressedData<double, 64> col) {
+			return Huffman::sum_where_op_range<double, 64>(col.dictionary, col.compressed, col.bounds);
+		};
+		//func(compressedData);
+		auto runtimes = Huffman::benchmark_op_with_dtype<double, double>(compressedData, runs, warmup, clearCache, func);
+		opResult.aggregateRuntimes.push_back(runtimes);
+		opResult.aggregateNames.push_back("sum_totalprice");
+		results.push_back(opResult);
 
-	//TOTALPRICE < 229815.16 (80% selectivity)
-	func = [](Huffman::compressedData<double, 64> col) {
-	 					return Huffman::sum_where_op_range<double, 64>(col.dictionary, col.compressed, col.bounds, NULL, 229815.16);
-	 				};
-	runtimes = Huffman::benchmark_op_with_dtype<double, double>(compressedData, runs, warmup, clearCache, func);
-	opResult.aggregateRuntimes.push_back(runtimes);
-	opResult.aggregateNames.push_back("sum_totalprice_80");
-	results.push_back(opResult);
+		//TOTALPRICE < 229815.16 (80% selectivity)
+		func = [](Huffman::compressedData<double, 64> col) {
+			return Huffman::sum_where_op_range<double, 64>(col.dictionary, col.compressed, col.bounds, NULL, 229815.16);
+		};
+		runtimes = Huffman::benchmark_op_with_dtype<double, double>(compressedData, runs, warmup, clearCache, func);
+		opResult.aggregateRuntimes.push_back(runtimes);
+		opResult.aggregateNames.push_back("sum_totalprice_80");
+		results.push_back(opResult);
 
+		//TOTALPRICE < 99498.77 (50% selectivity)
+		func = [](Huffman::compressedData<double, 64> col) {
+			return Huffman::sum_where_op_range<double, 64>(col.dictionary, col.compressed, col.bounds, NULL, 99498.77);
+		};
+		runtimes = Huffman::benchmark_op_with_dtype<double, double>(compressedData, runs, warmup, clearCache, func);
+		opResult.aggregateRuntimes.push_back(runtimes);
+		opResult.aggregateNames.push_back("sum_totalprice_50");
+		results.push_back(opResult);
 
-	//TOTALPRICE < 99498.77 (50% selectivity)
-	func = [](Huffman::compressedData<double, 64> col) {
-	 					return Huffman::sum_where_op_range<double, 64>(col.dictionary, col.compressed, col.bounds, NULL, 99498.77);
-	 				};
-	runtimes = Huffman::benchmark_op_with_dtype<double, double>(compressedData, runs, warmup, clearCache, func);
-	opResult.aggregateRuntimes.push_back(runtimes);
-	opResult.aggregateNames.push_back("sum_totalprice_50");
-	results.push_back(opResult);
-
-	//TOTALPRICE < 21871.0 (1% selcectivity)
-	func = [](Huffman::compressedData<double, 64> col) {
-	 					return Huffman::sum_where_op_range<double, 64>(col.dictionary, col.compressed, col.bounds, NULL, 21871.0);
-	 				};
-	runtimes = Huffman::benchmark_op_with_dtype<double, double>(compressedData, runs, warmup, clearCache, func);
-	opResult.aggregateRuntimes.push_back(runtimes);
-	opResult.aggregateNames.push_back("sum_totalprice_1");
-	results.push_back(opResult);
+		//TOTALPRICE < 21871.0 (1% selcectivity)
+		func = [](Huffman::compressedData<double, 64> col) {
+			return Huffman::sum_where_op_range<double, 64>(col.dictionary, col.compressed, col.bounds, NULL, 21871.0);
+		};
+		runtimes = Huffman::benchmark_op_with_dtype<double, double>(compressedData, runs, warmup, clearCache, func);
+		opResult.aggregateRuntimes.push_back(runtimes);
+		opResult.aggregateNames.push_back("sum_totalprice_1");
+		results.push_back(opResult);
 	}
-	
+
 	{
-	//CLERK:​
-	int i = 6; //CLERK
-	std::vector<std::string> convertedColumn;
-	std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string & str) { return str; });
-	auto compressedColumn = Huffman::compress<std::string, 64>(convertedColumn);
-	Huffman::compressedData<std::string, 64> compressedData;
-	compressedData.dictionary = std::get<0>(compressedColumn);
-	compressedData.compressed = std::get<1>(compressedColumn);
-	compressedData.bounds = std::get<2>(compressedColumn);
+		//CLERK:​
+		int i = 6; //CLERK
+		std::vector<std::string> convertedColumn;
+		std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string &str) { return str; });
+		auto compressedColumn = Huffman::compress<std::string, 64>(convertedColumn);
+		Huffman::compressedData<std::string, 64> compressedData;
+		compressedData.dictionary = std::get<0>(compressedColumn);
+		compressedData.compressed = std::get<1>(compressedColumn);
+		compressedData.bounds = std::get<2>(compressedColumn);
 
+		// 80 (80.31 %): x >= "Clerk#000001980"​
+		auto func = [](Huffman::compressedData<std::string, 64> col) {
+			return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {"Clerk#000001980"}, {});
+		};
+		auto runtimes = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
+		opResult.aggregateRuntimes.push_back(runtimes);
+		opResult.aggregateNames.push_back("count_clerk_80");
+		results.push_back(opResult);
 
-	// 80 (80.31 %): x >= "Clerk#000001980"​
-	auto func = [](Huffman::compressedData<std::string, 64> col) {
-	 					return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {"Clerk#000001980"}, {});
-	 				};
-	auto runtimes = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
-	opResult.aggregateRuntimes.push_back(runtimes);
-	opResult.aggregateNames.push_back("count_clerk_80");
-	results.push_back(opResult);
-	
+		// 50 (50.17 %): x <= "Clerk#000005100"​
+		auto func2 = [](Huffman::compressedData<std::string, 64> col) {
+			return Huffman::values_where_range_op<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"Clerk#000001980"});
+		};
+		runtimes = Huffman::benchmark_op_with_dtype<std::string, std::vector<std::string>>(compressedData, runs, warmup, clearCache, func2);
+		opResult.aggregateRuntimes.push_back(runtimes);
+		opResult.aggregateNames.push_back("values_clerk_50");
+		results.push_back(opResult);
 
-	// 50 (50.17 %): x <= "Clerk#000005100"​
-	auto func2 = [](Huffman::compressedData<std::string, 64> col) {
-	 					return Huffman::values_where_range_op<std::string, 64>(col.dictionary, col.compressed,col.bounds, {}, {"Clerk#000001980"});
-	 				};
-	runtimes = Huffman::benchmark_op_with_dtype<std::string, std::vector<std::string>>(compressedData, runs, warmup, clearCache, func2);
-	opResult.aggregateRuntimes.push_back(runtimes);
-	opResult.aggregateNames.push_back("values_clerk_50");
-	results.push_back(opResult);
-
-	// // 10 (10.31 %): x <= "Clerk#000000741"​
-	auto func3 = [](Huffman::compressedData<std::string, 64> col) {
-	 					return Huffman::values_where_range_op<std::string, 64>(col.dictionary, col.compressed,col.bounds, {}, {"Clerk#000000741"});
-	 				};
-	runtimes = Huffman::benchmark_op_with_dtype<std::string, std::vector<std::string>>(compressedData, runs, warmup, clearCache, func3);
-	opResult.aggregateRuntimes.push_back(runtimes);
-	opResult.aggregateNames.push_back("values_clerk_10");
-	results.push_back(opResult);
-
-}
+		// // 10 (10.31 %): x <= "Clerk#000000741"​
+		auto func3 = [](Huffman::compressedData<std::string, 64> col) {
+			return Huffman::values_where_range_op<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"Clerk#000000741"});
+		};
+		runtimes = Huffman::benchmark_op_with_dtype<std::string, std::vector<std::string>>(compressedData, runs, warmup, clearCache, func3);
+		opResult.aggregateRuntimes.push_back(runtimes);
+		opResult.aggregateNames.push_back("values_clerk_10");
+		results.push_back(opResult);
+	}
 	// ​
 	{
-	// ORDERPRIORITY:​
-	int i = 5; //ORDERPRIORITY
-	std::vector<std::string> convertedColumn;
-	std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string & str) { return str; });
-	auto compressedColumn = Huffman::compress<std::string, 64>(convertedColumn);
-	Huffman::compressedData<std::string, 64> compressedData;
-	compressedData.dictionary = std::get<0>(compressedColumn);
-	compressedData.compressed = std::get<1>(compressedColumn);
-	compressedData.bounds = std::get<2>(compressedColumn);
+		// ORDERPRIORITY:​
+		int i = 5; //ORDERPRIORITY
+		std::vector<std::string> convertedColumn;
+		std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string &str) { return str; });
+		auto compressedColumn = Huffman::compress<std::string, 64>(convertedColumn);
+		Huffman::compressedData<std::string, 64> compressedData;
+		compressedData.dictionary = std::get<0>(compressedColumn);
+		compressedData.compressed = std::get<1>(compressedColumn);
+		compressedData.bounds = std::get<2>(compressedColumn);
 
-	// 80 (80.00%): x < "5"​
-	auto func = [](Huffman::compressedData<std::string, 64> col) {
-	 					return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"5"});
-	 				};
-	auto runtimes = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
-	opResult.aggregateRuntimes.push_back(runtimes);
-	opResult.aggregateNames.push_back("count_orderprio_80");
-	results.push_back(opResult);
+		// 80 (80.00%): x < "5"​
+		auto func = [](Huffman::compressedData<std::string, 64> col) {
+			return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"5"});
+		};
+		auto runtimes = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
+		opResult.aggregateRuntimes.push_back(runtimes);
+		opResult.aggregateNames.push_back("count_orderprio_80");
+		results.push_back(opResult);
 
-	// // // 60 (59.99 %): x < "4"​
-	auto func2 = [](Huffman::compressedData<std::string, 64> col) {
-	 					return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"4"});
-	 				};
-	auto runtimes2 = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
-	opResult.aggregateRuntimes.push_back(runtimes2);
-	opResult.aggregateNames.push_back("count_orderprio_60");
-	results.push_back(opResult);
+		// // // 60 (59.99 %): x < "4"​
+		auto func2 = [](Huffman::compressedData<std::string, 64> col) {
+			return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"4"});
+		};
+		auto runtimes2 = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
+		opResult.aggregateRuntimes.push_back(runtimes2);
+		opResult.aggregateNames.push_back("count_orderprio_60");
+		results.push_back(opResult);
 
-	// // (40 (40.00%): x < "3")​
-	auto func3 = [](Huffman::compressedData<std::string, 64> col) {
-	 					return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"4"});
-	 				};
-	auto runtimes3 = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func2);
-	opResult.aggregateRuntimes.push_back(runtimes3);
-	opResult.aggregateNames.push_back("count_orderprio_40");
-	results.push_back(opResult);
+		// // (40 (40.00%): x < "3")​
+		auto func3 = [](Huffman::compressedData<std::string, 64> col) {
+			return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"4"});
+		};
+		auto runtimes3 = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func2);
+		opResult.aggregateRuntimes.push_back(runtimes3);
+		opResult.aggregateNames.push_back("count_orderprio_40");
+		results.push_back(opResult);
 
-	// // 20 (20.01%): x < "2"​
-	auto func4 = [](Huffman::compressedData<std::string, 64> col) {
-	 					return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"2"});
-	 				};
-	auto runtimes4 = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
-	opResult.aggregateRuntimes.push_back(runtimes4);
-	opResult.aggregateNames.push_back("count_orderprio_20");
-	results.push_back(opResult);
+		// // 20 (20.01%): x < "2"​
+		auto func4 = [](Huffman::compressedData<std::string, 64> col) {
+			return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {}, {"2"});
+		};
+		auto runtimes4 = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
+		opResult.aggregateRuntimes.push_back(runtimes4);
+		opResult.aggregateNames.push_back("count_orderprio_20");
+		results.push_back(opResult);
 	}
 
 	{
 		// 	ORDERDATE:​
 		int i = 4;
 		std::vector<std::time_t> convertedColumn;
-		auto transform_fn = [](const std::string & str) {
+		auto transform_fn = [](const std::string &str) {
 			std::tm t = {};
 			std::istringstream ss(str);
 			ss >> std::get_time(&t, "%Y-%m-%d");
-			if (ss.fail()) {
+			if (ss.fail())
+			{
 				throw std::invalid_argument("Cannot convert " + str + " to time");
 			}
 			return std::mktime(&t);
 		};
 		std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), transform_fn);
-	auto compressedColumn = Huffman::compress<std::time_t, 64>(convertedColumn);
-	Huffman::compressedData<std::time_t, 64> compressedData;
-	compressedData.dictionary = std::get<0>(compressedColumn);
-	compressedData.compressed = std::get<1>(compressedColumn);
-	compressedData.bounds = std::get<2>(compressedColumn);
+		auto compressedColumn = Huffman::compress<std::time_t, 64>(convertedColumn);
+		Huffman::compressedData<std::time_t, 64> compressedData;
+		compressedData.dictionary = std::get<0>(compressedColumn);
+		compressedData.compressed = std::get<1>(compressedColumn);
+		compressedData.bounds = std::get<2>(compressedColumn);
 
-		// 80 (80.97 %): >= 1993-10-27 
-	
+		// 80 (80.97 %): >= 1993-10-27
 
-	// auto func = [](Huffman::compressedData<std::time_t, 64> col) {
-	// 				//date = ????
- 	// 				return Huffman::values_where_range_op<std::time_t, 64>(col.dictionary, col.compressed, col.bounds, {date}, {});
- 	// 			};
-	// auto runtimes = Huffman::benchmark_op_with_dtype<std::tm, size_t>(compressedData, runs, warmup, clearCache, func);
-	// opResult.aggregateRuntimes.push_back(runtimes);
-	// opResult.aggregateNames.push_back("values_date_80");
-	// results.push_back(opResult);
+		// auto func = [](Huffman::compressedData<std::time_t, 64> col) {
+		// 				//date = ????
+		// 				return Huffman::values_where_range_op<std::time_t, 64>(col.dictionary, col.compressed, col.bounds, {date}, {});
+		// 			};
+		// auto runtimes = Huffman::benchmark_op_with_dtype<std::tm, size_t>(compressedData, runs, warmup, clearCache, func);
+		// opResult.aggregateRuntimes.push_back(runtimes);
+		// opResult.aggregateNames.push_back("values_date_80");
+		// results.push_back(opResult);
 
-	
+		// 50 (53.11 %):  >= 1996-01-02​
 
-// 50 (53.11 %):  >= 1996-01-02​
+		// 10 (9.68 %): >= 1996-12-19​
 
-// 10 (9.68 %): >= 1996-12-19​
-
-// 1 (1.51 %): >= 1998-07-21​
+		// 1 (1.51 %): >= 1998-07-21​
 	}
 
+	// ​
 
+	{
+		// CUSTKEY:​
+		int i = 1;
+		std::vector<std::string> convertedColumn;
+		std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string &str) { return str; });
+		auto compressedColumn = Huffman::compress<std::string, 64>(convertedColumn);
+		Huffman::compressedData<std::string, 64> compressedData;
+		compressedData.dictionary = std::get<0>(compressedColumn);
+		compressedData.compressed = std::get<1>(compressedColumn);
+		compressedData.bounds = std::get<2>(compressedColumn);
 
+		// 80 (80.00 %): >= 184560​
+		auto func = [](Huffman::compressedData<std::string, 64> col) {
+			return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {"184560​"}, {});
+		};
+		auto runtimes = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
+		opResult.aggregateRuntimes.push_back(runtimes);
+		opResult.aggregateNames.push_back("count_custkey_80");
+		results.push_back(opResult);
 
+		// 50 (50.00 %): >= 452260​
+		auto func2 = [](Huffman::compressedData<std::string, 64> col) {
+			return Huffman::values_where_range_op<std::string, 64>(col.dictionary, col.compressed, col.bounds, {"452260​"}, {});
+		};
+		runtimes = Huffman::benchmark_op_with_dtype<std::string, std::vector<std::string>>(compressedData, runs, warmup, clearCache, func2);
+		opResult.aggregateRuntimes.push_back(runtimes);
+		opResult.aggregateNames.push_back("values_custkey_50");
+		results.push_back(opResult);
 
-// ​
+		// 10 (10.00 %): >= 810600​
+		auto func3 = [](Huffman::compressedData<std::string, 64> col) {
+			return Huffman::values_where_range_op<std::string, 64>(col.dictionary, col.compressed, col.bounds, {"810600​"}, {});
+		};
+		runtimes = Huffman::benchmark_op_with_dtype<std::string, std::vector<std::string>>(compressedData, runs, warmup, clearCache, func3);
+		opResult.aggregateRuntimes.push_back(runtimes);
+		opResult.aggregateNames.push_back("values_custkey_10");
+		results.push_back(opResult);
+	}
 
-{
-// CUSTKEY:​
-int i = 1;
-std::vector<std::string> convertedColumn;
-	std::transform(table[i].begin(), table[i].end(), std::back_inserter(convertedColumn), [](const std::string & str) { return str; });
-	auto compressedColumn = Huffman::compress<std::string, 64>(convertedColumn);
-	Huffman::compressedData<std::string, 64> compressedData;
-	compressedData.dictionary = std::get<0>(compressedColumn);
-	compressedData.compressed = std::get<1>(compressedColumn);
-	compressedData.bounds = std::get<2>(compressedColumn);
+	// ​
 
-
-	// 80 (80.00 %): >= 184560​
-	auto func = [](Huffman::compressedData<std::string, 64> col) {
-	 					return Huffman::count_where_op_range<std::string, 64>(col.dictionary, col.compressed, col.bounds, {"184560​"}, {});
-	 				};
-	auto runtimes = Huffman::benchmark_op_with_dtype<std::string, size_t>(compressedData, runs, warmup, clearCache, func);
-	opResult.aggregateRuntimes.push_back(runtimes);
-	opResult.aggregateNames.push_back("count_custkey_80");
-	results.push_back(opResult);
-	
-
-	// 50 (50.00 %): >= 452260​
-	auto func2 = [](Huffman::compressedData<std::string, 64> col) {
-	 					return Huffman::values_where_range_op<std::string, 64>(col.dictionary, col.compressed,col.bounds, {"452260​"}, {});
-	 				};
-	runtimes = Huffman::benchmark_op_with_dtype<std::string, std::vector<std::string>>(compressedData, runs, warmup, clearCache, func2);
-	opResult.aggregateRuntimes.push_back(runtimes);
-	opResult.aggregateNames.push_back("values_custkey_50");
-	results.push_back(opResult);
-
-	
-
-	// 10 (10.00 %): >= 810600​
-	auto func3 = [](Huffman::compressedData<std::string, 64> col) {
-	 					return Huffman::values_where_range_op<std::string, 64>(col.dictionary, col.compressed,col.bounds, {"810600​"}, {});
-	 				};
-	runtimes = Huffman::benchmark_op_with_dtype<std::string, std::vector<std::string>>(compressedData, runs, warmup, clearCache, func3);
-	opResult.aggregateRuntimes.push_back(runtimes);
-	opResult.aggregateNames.push_back("values_custkey_10");
-	results.push_back(opResult);
-
-}
-
-// ​
-	
-	
 	std::cout << "Slide Aggs - Finished" << std::endl;
 	std::vector<double> cRatios;
 	std::vector<size_t> cSizes;
 	std::vector<size_t> uSizes;
 	std::vector<std::vector<size_t>> cTimes;
 	std::vector<std::vector<size_t>> dcTimes;
-	for (int j = 0; j < results.size(); ++j) {
+	for (int j = 0; j < results.size(); ++j)
+	{
 		for (int i = 0; i < results[j].aggregateRuntimes.size(); ++i)
 		{
 			auto times = results[j].aggregateRuntimes[i];
@@ -749,9 +772,8 @@ std::vector<std::string> convertedColumn;
 	}
 }
 
-
-
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[])
+{
 	int runs = 3;
 	int warmup = 1;
 	bool clearCache = false;
@@ -767,39 +789,48 @@ int main(int argc, char* argv[]) {
 	bool compress = false;
 	bool op = false;
 	bool slides = false;
-	for (auto arg : args) {
-		if (arg == "-dictionary") {
+	for (auto arg : args)
+	{
+		if (arg == "-dictionary")
+		{
 			std::cout << "Enabled: dictionary" << std::endl;
 			dictionary = true;
 		}
-		else if (arg == "-huffman") {
+		else if (arg == "-huffman")
+		{
 			std::cout << "Enabled: huffman" << std::endl;
 			huffman = true;
 		}
-		else if (arg == "-compress") {
+		else if (arg == "-compress")
+		{
 			std::cout << "Enabled: compress" << std::endl;
 			compress = true;
 		}
-		else if (arg == "-op") {
+		else if (arg == "-op")
+		{
 			std::cout << "Enabled: op" << std::endl;
 			op = true;
 		}
-		else if (arg == "-slide-aggs") {
+		else if (arg == "-slide-aggs")
+		{
 			std::cout << "Enabled: benchmark for aggregation in slides" << std::endl;
 			slides = true;
 		}
-		else {
+		else
+		{
 			std::cerr << arg << " is an unrecognised flag.\nThe following flags are allowed:\n\t-dictionary\n\t-huffman\n\t-compress (enables compression benchmarks)\n\t-op (enables operation benchmarks)\n\tor no flag of either pairs to enable both" << std::endl;
 			return 1;
 		}
 	}
-	if (compress == false && op == false && !slides) {
+	if (compress == false && op == false && !slides)
+	{
 		std::cout << "Enabled: compress" << std::endl;
 		compress = true;
 		std::cout << "Enabled: op" << std::endl;
 		op = true;
 	}
-	if (dictionary == false && huffman == false && !slides) {
+	if (dictionary == false && huffman == false && !slides)
+	{
 		std::cout << "Enabled: dictionary" << std::endl;
 		dictionary = true;
 		std::cout << "Enabled: huffman" << std::endl;
@@ -823,19 +854,24 @@ int main(int argc, char* argv[]) {
 	std::string cTimesFile = "compression_times.csv";
 	std::string dcTimesFile = "decompression_times.csv";
 
-
 	// ------------------- Dictionary -------------- //
-	try {
-		if (dictionary) {
+	try
+	{
+		if (dictionary)
+		{
 			fullDictionaryBenchmark(table, header, runs, warmup, clearCache, compress, op, cRatioFile, cSizeFile, uSizeFile, cTimesFile, dcTimesFile);
 		}
-		if (huffman) {
+		if (huffman)
+		{
 			fullHuffmanBenchmark(table, header, runs, warmup, clearCache, cRatioFile, cSizeFile, uSizeFile, cTimesFile, dcTimesFile);
 		}
-		if (slides) {
+		if (slides)
+		{
 			slidesBenchmark(table, header, runs, warmup, clearCache, cRatioFile, cSizeFile, uSizeFile, cTimesFile, dcTimesFile);
 		}
-	} catch (const std::invalid_argument& e) {
+	}
+	catch (const std::invalid_argument &e)
+	{
 		return 0;
 	}
 	return 1;


### PR DESCRIPTION
Die Slide aggregates von der Folie.

* Warnung können ignoriert werden.
* Habe umgestellt auf std::optional für range queries.
* Range queries bekommen einen `from` und einen `to` Parameter. `from`ist immer eingeschlossen. `to` ist immer ausgeschlossen.
* orderdate fehlt noch
* zum starten mit `-slide-aggs`

@sleighsoft kannst du die benchmarks einmal auf deinem server laufen lassen? 

